### PR TITLE
Initial version of TableUnspanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # TableUnspanner
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/table_unspanner`. To experiment with that code, run `bin/console` for an interactive prompt.
-
-TODO: Delete this and the text above, and describe your gem
+Takes a table with `rowspan` and/or `colspan` attributes on `<th>` and `<td>`
+elements and returns a version of the table with those replaced by duplicate
+rows to make scraping easier.
 
 ## Installation
 
@@ -22,7 +22,29 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+### Standalone
+
+```ruby
+require 'table_unspanner'
+
+table = <<-TABLE
+<table>
+  <tr>
+    <th>Name</th>
+    <th>Role</th>
+  </tr>
+  <tr>
+    <td>Alice</td>
+    <td rowspan="2">Test subject</td>
+  </tr>
+  <tr>
+    <td>Bob</td>
+  </tr>
+</table>
+TABLE
+
+puts TableUnspanner::UnspannedTable.new(table: table).to_s
+```
 
 ## Development
 
@@ -32,5 +54,4 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/table_unspanner.
-
+Bug reports and pull requests are welcome on GitHub at https://github.com/everypolitician/table_unspanner.

--- a/README.md
+++ b/README.md
@@ -43,9 +43,25 @@ table = <<-TABLE
 </table>
 TABLE
 
-puts TableUnspanner::UnspannedTable.new(table: table).children
-# => <tr><th>Name</th><th>Role</th></tr><tr><td>Alice</td><td>Test subject</td></tr><tr><td>Bob</td><td>Test subject</td></tr>
+puts TableUnspanner::UnspannedTable.new(table: table).to_s
 ```
+
+When the above code is run it will output the following:
+
+    <table>
+      <tr>
+        <th>Name</th>
+        <th>Role</th>
+      </tr>
+      <tr>
+        <td>Alice</td>
+        <td>Test subject</td>
+      </tr>
+      <tr>
+        <td>Bob</td>
+        <td>Test subject</td>
+      </tr>
+    </table>
 
 ### With `scraped`
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ table = <<-TABLE
 </table>
 TABLE
 
-puts TableUnspanner::UnspannedTable.new(table: table).to_s
+puts TableUnspanner::UnspannedTable.new(table: table).children
 ```
 
 ### With `scraped`

--- a/README.md
+++ b/README.md
@@ -46,6 +46,22 @@ TABLE
 puts TableUnspanner::UnspannedTable.new(table: table).to_s
 ```
 
+### With `scraped`
+
+This library comes with support for
+[`scraped`](https://github.com/everypolitician/scraped) out of the box. You can
+use it as a decorator and it will unspan _all_ the tables on the current page.
+
+```ruby
+require 'table_unspanner/scraped'
+
+class MemberPage < Scraped::HTML
+  decorator TableUnspanner::Decorator
+
+  # Other fields etc
+end
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ table = <<-TABLE
 TABLE
 
 puts TableUnspanner::UnspannedTable.new(table: table).children
+# => <tr><th>Name</th><th>Role</th></tr><tr><td>Alice</td><td>Test subject</td></tr><tr><td>Bob</td><td>Test subject</td></tr>
 ```
 
 ### With `scraped`

--- a/lib/table_unspanner.rb
+++ b/lib/table_unspanner.rb
@@ -8,9 +8,8 @@ module TableUnspanner
       @table = Nokogiri::HTML.fragment(table.to_s).at_css('table')
     end
 
-    def to_s
-      table.children = reparsed.map { |c| '<tr>' + c.map(&:to_html).join + '</tr>' }.join
-      table.to_s
+    def children
+      reparsed.map { |c| '<tr>' + c.map(&:to_html).join + '</tr>' }.join
     end
 
     private

--- a/lib/table_unspanner.rb
+++ b/lib/table_unspanner.rb
@@ -1,5 +1,40 @@
 require 'table_unspanner/version'
+require 'nokogiri'
 
 module TableUnspanner
-  # Your code goes here...
+  class UnspannedTable
+    def initialize(table:)
+      @original = table
+      @table = Nokogiri::HTML.fragment(table.to_s).at_css('table')
+    end
+
+    def to_s
+      table.children = reparsed.map { |c| '<tr>' + c.map(&:to_html).join + '</tr>' }.join
+      table.to_s
+    end
+
+    private
+
+    attr_reader :table
+
+    def reparsed
+      grid = []
+
+      table.css('tr').each_with_index do |row, curr_x|
+        row.css('td, th').each_with_index do |cell, curr_y|
+          rowspan = cell.remove_attribute('rowspan').value.to_i rescue 1
+          colspan = cell.remove_attribute('colspan').value.to_i rescue 1
+
+          0.upto(rowspan - 1).each do |x|
+            0.upto(colspan - 1).each do |y|
+              curr_y += 1 while (grid[curr_x + x] ||= [])[curr_y + y]
+              grid[curr_x + x][curr_y + y] = cell
+            end
+          end
+        end
+      end
+
+      grid
+    end
+  end
 end

--- a/lib/table_unspanner/scraped.rb
+++ b/lib/table_unspanner/scraped.rb
@@ -1,4 +1,5 @@
 require 'scraped'
+require 'table_unspanner'
 
 module TableUnspanner
   class Decorator < Scraped::Response::Decorator

--- a/lib/table_unspanner/scraped.rb
+++ b/lib/table_unspanner/scraped.rb
@@ -1,0 +1,13 @@
+require 'scraped'
+
+module TableUnspanner
+  class Decorator < Scraped::Response::Decorator
+    def body
+      Nokogiri::HTML(super).tap do |doc|
+        doc.css('table').each do |table|
+          table.children = UnspannedTable.new(table).children
+        end
+      end.to_s
+    end
+  end
+end

--- a/lib/table_unspanner/scraped.rb
+++ b/lib/table_unspanner/scraped.rb
@@ -6,7 +6,7 @@ module TableUnspanner
     def body
       Nokogiri::HTML(super).tap do |doc|
         doc.css('table').each do |table|
-          table.children = UnspannedTable.new(table).children
+          table.children = UnspannedTable.new(table: table).children
         end
       end.to_s
     end

--- a/table_unspanner.gemspec
+++ b/table_unspanner.gemspec
@@ -9,18 +9,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Chris Mytton']
   spec.email         = ['chrismytton@gmail.com']
 
-  spec.summary       = 'TODO: Write a short summary, because Rubygems requires one.'
-  spec.description   = 'TODO: Write a longer description or delete this line.'
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
-
-  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
-  # to allow pushing to a single host or delete this section to allow pushing to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
-  else
-    raise 'RubyGems 2.0 or newer is required to protect against ' \
-      'public gem pushes.'
-  end
+  spec.summary       = 'Remove rowspan and colspan attributes from HTML tables to make scraping easier.'
+  spec.homepage      = 'https://github.com/everypolitician/table_unspanner'
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
@@ -29,7 +19,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_runtime_dependency 'nokogiri'
+
   spec.add_development_dependency 'bundler', '~> 1.13'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'minitest', '~> 5.0'
+  spec.add_development_dependency 'pry', '~> 0.10'
 end

--- a/test/table_unspanner_test.rb
+++ b/test/table_unspanner_test.rb
@@ -1,11 +1,46 @@
 require 'test_helper'
 
-class TableUnspannerTest < Minitest::Test
-  def test_that_it_has_a_version_number
-    refute_nil ::TableUnspanner::VERSION
+describe 'TableUnspanner' do
+  it 'has a version number' do
+    ::TableUnspanner::VERSION.wont_be_nil
   end
 
-  def test_it_does_something_useful
-    assert false
+  describe 'UnspannedTable' do
+    it 'replaces span elements with multiple cells' do
+      table = <<-TABLE
+      <table>
+        <tr>
+          <th>Name</th>
+          <th>Role</th>
+        </tr>
+        <tr>
+          <td>Alice</td>
+          <td rowspan="2">Test subject</td>
+        </tr>
+        <tr>
+          <td>Bob</td>
+        </tr>
+      </table>
+      TABLE
+
+      expected = <<-TABLE
+<table>
+<tr>
+<th>Name</th>
+<th>Role</th>
+</tr>
+<tr>
+<td>Alice</td>
+<td>Test subject</td>
+</tr>
+<tr>
+<td>Bob</td>
+<td>Test subject</td>
+</tr>
+</table>
+      TABLE
+
+      TableUnspanner::UnspannedTable.new(table: table).to_s.strip.must_equal expected.strip
+    end
   end
 end

--- a/test/table_unspanner_test.rb
+++ b/test/table_unspanner_test.rb
@@ -23,24 +23,10 @@ describe 'TableUnspanner' do
       </table>
       TABLE
 
-      expected = <<-TABLE
-<table>
-<tr>
-<th>Name</th>
-<th>Role</th>
-</tr>
-<tr>
-<td>Alice</td>
-<td>Test subject</td>
-</tr>
-<tr>
-<td>Bob</td>
-<td>Test subject</td>
-</tr>
-</table>
-      TABLE
+      expected = "<tr><th>Name</th><th>Role</th></tr><tr><td>Alice</td>" \
+        "<td>Test subject</td></tr><tr><td>Bob</td><td>Test subject</td></tr>"
 
-      TableUnspanner::UnspannedTable.new(table: table).to_s.strip.must_equal expected.strip
+      TableUnspanner::UnspannedTable.new(table: table).children.must_equal expected
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'table_unspanner'
+require 'pry'
 
 require 'minitest/autorun'


### PR DESCRIPTION
This is a port of the `<table>` unspanning code from https://github.com/everypolitician-scrapers/turkey-tbmm-wikipedia/pull/3.

# Notes to reviewer

You can see this in action in https://github.com/everypolitician-scrapers/turkey-tbmm-wikipedia/pull/3.

The naming is currently a bit odd, the module is called `TableUnspanner` and that in turn contains a `UnspannedTable` class. I _think_ this makes sense, `TableUnspanner` is the library name, `UnspannedTable` is the object that represents a table that has been unspanned. However I am open to persuasion that this should be changed :)