### PR TITLE
Make sure we can cope with a blank node mid-row

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.4
 
 inherit_from:
   - https://raw.githubusercontent.com/everypolitician/everypolitician-data/master/.rubocop_base.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - 2.1
   - 2.2
-  - 2.3.3
-before_install: gem install bundler -v 1.13.5
+  - 2.3
+  - 2.4
+  - 2.5

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in table_unspanner.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 require 'rubocop/rake_task'
@@ -10,4 +12,4 @@ Rake::TestTask.new(:test) do |t|
   t.test_files = FileList['test/**/*_test.rb']
 end
 
-task default: %w(test rubocop)
+task default: %w[test rubocop]

--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'bundler/setup'
 require 'table_unspanner'

--- a/lib/table_unspanner.rb
+++ b/lib/table_unspanner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'table_unspanner/version'
 require 'nokogiri'
 
@@ -8,7 +10,9 @@ module TableUnspanner
     end
 
     def nokogiri_node
-      table.children = reparsed.map { |c| '<tr>' + c.map { |n| n ? n.to_html : "<td>" }.join + '</tr>' }.join
+      table.children = reparsed.map do |c|
+        '<tr>' + c.map { |n| n ? n.to_html : '<td>' }.join + '</tr>'
+      end.join
       table
     end
 

--- a/lib/table_unspanner.rb
+++ b/lib/table_unspanner.rb
@@ -8,7 +8,7 @@ module TableUnspanner
     end
 
     def nokogiri_node
-      table.children = reparsed.map { |c| '<tr>' + c.map(&:to_html).join + '</tr>' }.join
+      table.children = reparsed.map { |c| '<tr>' + c.map { |n| n ? n.to_html : "<td>" }.join + '</tr>' }.join
       table
     end
 

--- a/lib/table_unspanner/version.rb
+++ b/lib/table_unspanner/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module TableUnspanner
-  VERSION = '0.1.0'.freeze
+  VERSION = '0.1.0'
 end

--- a/lib/table_unspanner/version.rb
+++ b/lib/table_unspanner/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TableUnspanner
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end

--- a/table_unspanner.gemspec
+++ b/table_unspanner.gemspec
@@ -1,5 +1,6 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'table_unspanner/version'
 
@@ -23,8 +24,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'nokogiri'
 
   spec.add_development_dependency 'bundler', '~> 1.13'
-  spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'pry', '~> 0.10'
+  spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rubocop'
 end

--- a/test/blank_test.rb
+++ b/test/blank_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 describe 'TableUnspanner' do

--- a/test/blank_test.rb
+++ b/test/blank_test.rb
@@ -1,0 +1,101 @@
+require 'test_helper'
+
+describe 'TableUnspanner' do
+  it 'has a version number' do
+    ::TableUnspanner::VERSION.wont_be_nil
+  end
+
+  let(:unspanned_table) do
+    TableUnspanner::UnspannedTable.new(given_table)
+  end
+
+  let(:noko) do
+    unspanned_table.nokogiri_node
+  end
+
+  describe 'UnspannedTable' do
+    describe 'with rowspan attributes' do
+      let(:given_table) do
+        <<-TABLE.gsub(/^ +/, '')
+          <table>
+            <tr>
+              <th rowspan="3">Employees</th>
+              <th>Name</th>
+              <th>Role</th>
+              <th colspan="2">Start/End</th>
+            </tr>
+            <tr>
+              <td>Alice</td>
+              <td>Adviser</td>
+              <td>2016-01-01</td>
+              <td rowspan="2">2016-10-31</td>
+            </tr>
+            <tr>
+              <td>Bob</td>
+              <td>Builder</td>
+            </tr>
+          </table>
+        TABLE
+      end
+
+      let(:expected_table) do
+        <<-TABLE.gsub(/^ +/, '')
+          <table>
+            <tr>
+              <th>Employees</th>
+              <th>Name</th>
+              <th>Role</th>
+              <th>Start/End</th>
+              <th>Start/End</th>
+            </tr>
+            <tr>
+              <th>Employees</th>
+              <td>Alice</td>
+              <td>Adviser</td>
+              <td>2016-01-01</td>
+              <td>2016-10-31</td>
+            </tr>
+            <tr>
+              <th>Employees</th>
+              <td>Bob</td>
+              <td>Builder</td>
+              <td></td>
+              <td>2016-10-31</td>
+            </tr>
+          </table>
+        TABLE
+      end
+
+      it 'gets the header row correct' do
+        row = noko.xpath('tr[1]/th').map(&:text)
+        row[0].must_equal 'Employees'
+        row[1].must_equal 'Name'
+        row[2].must_equal 'Role'
+        row[3].must_equal 'Start/End'
+        row[4].must_equal 'Start/End'
+      end
+
+      it 'gets Alice correct' do
+        noko.xpath('.//tr[2]/th').text.must_equal 'Employees'
+        row = noko.xpath('.//tr[2]/td').map(&:text)
+        row[0].must_equal 'Alice'
+        row[1].must_equal 'Adviser'
+        row[2].must_equal '2016-01-01'
+        row[3].must_equal '2016-10-31'
+      end
+
+      it 'gets Bob correct' do
+        noko.xpath('.//tr[3]/th').text.must_equal 'Employees'
+        row = noko.xpath('.//tr[3]/td').map(&:text)
+        row[0].must_equal 'Bob'
+        row[1].must_equal 'Builder'
+        row[2].must_equal ''
+        row[3].must_equal '2016-10-31'
+      end
+
+      it 'can be returned as a string' do
+        unspanned_table.html_string.strip.must_equal expected_table.strip
+      end
+    end
+  end
+end

--- a/test/table_unspanner_test.rb
+++ b/test/table_unspanner_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 describe 'TableUnspanner' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,6 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'table_unspanner'
 require 'pry'
 


### PR DESCRIPTION
If we have (for example) a 4th column provided by a span from the previous row, but this row finishes at the 2nd column (thus leaving the third column as entirely blank, rather than merely empty), make sure we fill in an empty cell.

This was encountered at Saint-Léonard—Saint-Michel on https://en.wikipedia.org/w/index.php?title=List_of_House_members_of_the_42nd_Parliament_of_Canada&oldid=883077879